### PR TITLE
Tumult Labs Open Source Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,35 @@ File A (Detailed DHC-A). A later source code release will contain the source
 code for SafeTab-H, the application used to protect the Detailed
 Demographic and Housing Characteristics File B (Detailed DHC-B).
 
-Using the mathematical principles of differential Privacy, SafeTab-P infused
-noise into Census survey results to create *privacy-protected
-statistics* which were used by Bureau subject matter experts to
-tabulate the 2020 Detailed DHC-A product. SafeTab-P was built on Tumult Analytics, a platform for computing statistics using differential Privacy. Both SafeTab-P and the underlying platform are implemented in Python. The latest version of Tumult Analytics can be found at https://tmlt.dev/.
+Using the mathematical principles of differential privacy, SafeTab-P infused
+noise into 2020 Census results to create *privacy-protected
+statistics* which were used by Census Bureau subject-matter experts to
+tabulate the 2020 Detailed DHC-A product. SafeTab-P was built on Tumult Analytics, a platform for computing statistics using differential privacy. Both SafeTab-P and the underlying platform are implemented in Python. The latest version of Tumult Analytics can be found at https://tmlt.dev/.
 
 In the interests of both transparency and scientific advancement, the
 Census Bureau committed to releasing any source code used in creation
 of products protected by formal privacy guarantees. In the case of the 
-Detailed Demographic & Housing Characteristics publications, this
+Detailed Demographic and Housing Characteristics publications, this
 includes code developed under contract by Tumult Labs (https://tmlt.io)
 and MITRE corporation. Tumult Analytics is an evolving platform and
 the code in the repository is from version 0.5.3.
 
 The Bureau has already separately released the internally developed
-software for the Top Down Algorithm (TDA) used in production of the
-2020 Redistricting and the 2020 Demographic & Housing Characteristics
+software for the TopDown Algorithm (TDA) used in production of the
+2020 Redistricting and the 2020 Demographic and Housing Characteristics
 products.
 
-The repo containing the 2020 DDHC-A product is divided into five subdirectories.:
+The repo containing the 2020 Detailed DHC-A product is divided into six subdirectories.:
 * `configs` contains the specific configuration files used for the
-  production Detailed DHC-A runs, including privacy loss budget (PLB) allocations
+  production Detailed DHC-A runs, including privacy-loss budget (PLB) allocations
   and the rules for adaptive table generation. These configurations reflect
-  decisions by the Bureau's DSEP (Data Stewardship Executive Policy) committee
+  decisions by the Census Bureau's Data Stewardship Executive Policy committee
   based on experiments conducted by Census Bureau staff.
 * `safetab_p` contains the source code for the application itself as used
-   to generate the protected microdata used in production.
+   to generate the protected statistics used in production.
 * `safetab_utils` contains utilities common among the SafeTab products
-  developed by Tumult for the Census Bureau.
-* `mitre/cef_readers` contains code by MITRE to read the Census input
+  developed by Tumult Labs for the Census Bureau.
+* `mitre/cef_readers` contains code by MITRE to read the 2020 Census input
   files used by the SafeTab applications.
 * `ctools` contains Python utility libraries developed by the Census
   Bureau's DAS team and used by the MITRE CEF readers.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ File A (Detailed DHC-A). A later source code release will contain the source
 code for SafeTab-H, the application used to protect the Detailed
 Demographic and Housing Characteristics File B (Detailed DHC-B).
 
-Using the mathematical principles of differential privacy, SafeTab-P infused
-noise into 2020 Census results to create *privacy-protected
-statistics* which were used by Census Bureau subject-matter experts to
-tabulate the 2020 Detailed DHC-A product. SafeTab-P was built on Tumult Analytics, a platform for computing statistics using differential privacy. Both SafeTab-P and the underlying platform are implemented in Python. The latest version of Tumult Analytics can be found at https://tmlt.dev/.
+Using the mathematical principles of differential privacy, SafeTab-P infused noise into 2020 Census results to create *privacy-protected statistics* which were used by Census Bureau subject-matter experts to tabulate the 2020 Detailed DHC-A product. SafeTab-P was built on Tumult Analytics, a platform for computing statistics using differential privacy. Both SafeTab-P and the underlying platform are implemented in Python. The latest version of Tumult Analytics can be found at https://tmlt.dev/.
 
 In the interests of both transparency and scientific advancement, the
 Census Bureau committed to releasing any source code used in creation

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ software for the TopDown Algorithm (TDA) used in production of the
 2020 Redistricting and the 2020 Demographic and Housing Characteristics
 products.
 
-The repo containing the 2020 Detailed DHC-A product is divided into six subdirectories.:
+This repository is divided into six subdirectories:
 * `configs` contains the specific configuration files used for the
   production Detailed DHC-A runs, including privacy-loss budget (PLB) allocations
   and the rules for adaptive table generation. These configurations reflect

--- a/README.md
+++ b/README.md
@@ -2,35 +2,31 @@ This repository contains source code for the SafeTab-P disclosure
 avoidance application. SafeTab-P was used by the Census Bureau for the
 protection of individual 2020 Census responses in the tabulation and
 publication of the Detailed Demographic and Housing Characteristics
-File A (DDHC-A). A later source code release will contain the source
+File A (Detailed DHC-A). A later source code release will contain the source
 code for SafeTab-H, the application used to protect the Detailed
-Demographic and Housing Characteristics File B (DDHC-B).
+Demographic and Housing Characteristics File B (Detailed DHC-B).
 
-Using the mathematical principles of formal privacy, SafeTab-P infused
+Using the mathematical principles of differential Privacy, SafeTab-P infused
 noise into Census survey results to create *privacy-protected
-microdata* which were used by Bureau subject matter experts to
-tabulate the 2020 DDHC-A product.  SafeTab-P was built on Tumult's
-"Analytics" and "Core" platforms. both SafeTab-P and the underlying
-platforms are implemented in Python. The latest version of the
-platforms can be found at https://tmlt.dev/.
+statistics* which were used by Bureau subject matter experts to
+tabulate the 2020 Detailed DHC-A product. SafeTab-P was built on Tumult Analytics, a platform for computing statistics using differential Privacy. Both SafeTab-P and the underlying platform are implemented in Python. The latest version of Tumult Analytics can be found at https://tmlt.dev/.
 
 In the interests of both transparency and scientific advancement, the
 Census Bureau committed to releasing any source code used in creation
-of products protected by formal privacy guarantees. In the case of the
-the Detailed Demographic & Housing Characteristics publications, this
-includes code developed under contract by Tumult Software (tmlt.io)
-and MITRE corporation. Tumult's underlying platform is evolving and
-the code in the repository is a snapshot of the code used for the
-DDHC-A.
+of products protected by formal privacy guarantees. In the case of the 
+Detailed Demographic & Housing Characteristics publications, this
+includes code developed under contract by Tumult Labs (https://tmlt.io)
+and MITRE corporation. Tumult Analytics is an evolving platform and
+the code in the repository is from version 0.5.3.
 
-The bureau has already separately released the internally developed
+The Bureau has already separately released the internally developed
 software for the Top Down Algorithm (TDA) used in production of the
 2020 Redistricting and the 2020 Demographic & Housing Characteristics
 products.
 
-This software for this repository is divided into five subdirectories:
+The repo containing the 2020 DDHC-A product is divided into five subdirectories.:
 * `configs` contains the specific configuration files used for the
-  production DDHC-A runs, including privacy loss budget (PLB) allocations
+  production Detailed DHC-A runs, including privacy loss budget (PLB) allocations
   and the rules for adaptive table generation. These configurations reflect
   decisions by the Bureau's DSEP (Data Stewardship Executive Policy) committee
   based on experiments conducted by Census Bureau staff.
@@ -40,7 +36,7 @@ This software for this repository is divided into five subdirectories:
   developed by Tumult for the Census Bureau.
 * `mitre/cef_readers` contains code by MITRE to read the Census input
   files used by the SafeTab applications.
-* `ctools` contains Python utility libraries developed the the Census
+* `ctools` contains Python utility libraries developed by the Census
   Bureau's DAS team and used by the MITRE CEF readers.
 * `tumult` contains the Tumult Analytics platform. This is divided
    into `common`, `analytics`, and `core` directories. The `core` directory

--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -1,8 +1,8 @@
 # Athors
 
-The following individuals contributed to the development of this software by Tumult and MITRE.
+The following individuals contributed to the development of this software by Tumult Labs and MITRE.
 
-## Tumult​
+## Tumult​ Labs
 
 * Gerome Miklau (U.S. Census Bureau Contractor/Tumult Labs; Professor at University of Massachusetts Amherst)​
 * Ashwin Machanavajjhala (U.S. Census Bureau Contractor/Tumult Labs; Professor at Duke University)​

--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -15,7 +15,7 @@ The following individuals contributed to the development of this software by Tum
 * Amritha Pai (U.S. Census Bureau Contractor/Tumult Labs)​
 * Ruchit Shrestha (U.S. Census Bureau Contractor/Tumult Labs)​
 * Skye Berghel (U.S. Census Bureau Contractor/Tumult Labs)​
-* Simiran Rajpal (U.S. Census Bureau Contractor/Tumult Labs)
+* Simran Rajpal (formerly U.S. Census Bureau Contractor/Tumult Labs)
 
 ## USCB Internal​
 

--- a/safetab_p/README.md
+++ b/safetab_p/README.md
@@ -103,17 +103,13 @@ export PYTHONPATH=$PYTHONPATH:$DIR/tumult/analytics
 
 `PYTHONPATH` also needs to be updated to include a Census Edited File (CEF) reader module for SafeTab `safetab_cef_reader.py`. This can be either MITRE’s CEF reader (developed separately), or the built-in mock CEF reader: `safetab_p/tmlt/mock_cef_reader`. Note that the mock CEF reader does not actually read CEF files, so it can only be used if input is being read from CSV files.
 
+To use the MITRE CEF reader and add it to the Python Path, run the following command:
+
 ```bash
 export PYTHONPATH=<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/mitre:$PYTHONPATH
 ```
 
-If using MITRE's CEF reader, you will also need to include its dependencies, which can be found in its `das_decennial` directory:
-
-```bash
-export PYTHONPATH=<path to das_decennial>:$PYTHONPATH
-```
-
-Consult the CEF reader README for more details.
+Consult the CEF reader [README](../mitre/cef-readers/README.md) for more details.
 
 ## Input Directory Structure
 There are two path inputs to SafeTab-P, a `parameters path` and a `data path`. This setup is replicated in the  `safetab_p/tmlt/safetab_p/resources/toy_dataset` directory. 

--- a/safetab_p/README.md
+++ b/safetab_p/README.md
@@ -81,7 +81,7 @@ If installing on an EMR cluster, Tumult Core can be installed with a boostrap ac
 Some environment variables need to be set. In particular, `PYSPARK_PYTHON` must be set to the correct python version:
 
 ```bash
-export PYSPARK_PYTHON=$(which python)
+export PYSPARK_PYTHON=$(which python3)
 ```
 
 If running on the master node of an EMR cluster, some libraries need to be added to the `PYTHONPATH`:

--- a/safetab_p/README.md
+++ b/safetab_p/README.md
@@ -40,7 +40,7 @@ All python dependencies, as specified in [requirements.txt](requirements.txt) mu
 When running locally, dependencies can be installed by running:
 
 ```bash
-sudo python3 -m pip install -r safetab_p/requirements.txt
+sudo python3 -m pip install -r <absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p/requirements.txt
 ```
 
 Note that one of the dependencies is PySpark, which requires Java 8 or later with `JAVA_HOME` properly set. If Java is not yet installed on your system, you can [install OpenJDK 8](https://openjdk.org/install/) (installation will vary based on the system type).
@@ -56,7 +56,7 @@ SafeTab-P also requires the Tumult Core library to be installed. Tumult Core can
 When running locally, Core can be installed by calling:
 
 ```bash
-sudo python3 -m pip install --no-deps core/tmlt_core-0.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+sudo python3 -m pip install --no-deps <absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/tumult/core/tmlt_core-0.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 ```
 When running on an EMR cluster, Tumult Core can be installed from the wheel file in a bootstrap action. Tumult Core is dependent on some of the [SafeTab-P requirements](requirements.txt) so ensure that the first EMR bootstrap action installs those dependencies. Then add a second bootstrap action to install Tumult Core using the following steps:
 1. Upload [`core/bootstrap_script.sh`](../tumult/core/bootstrap_script.sh), [`../tumult/core/test_script.py`](../tumult/core/test_script.py), and [`../tumult/core/tmlt_core-0.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`](../core/tmlt_core-0.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl) to an S3 bucket. 
@@ -81,7 +81,7 @@ If installing on an EMR cluster, Tumult Core can be installed with a boostrap ac
 Some environment variables need to be set. In particular, `PYSPARK_PYTHON` must be set to the correct python version:
 
 ```bash
-export PYSPARK_PYTHON=/usr/bin/python3
+export PYSPARK_PYTHON=$(which python)
 ```
 
 If running on the master node of an EMR cluster, some libraries need to be added to the `PYTHONPATH`:
@@ -93,18 +93,18 @@ export PYTHONPATH=/usr/lib/spark/python:/usr/lib/spark/python/lib:/usr/lib/spark
 `PYTHONPATH` needs to updated to include the Tumult source directories. This assumes that required Python dependencies have been installed.
 
 ```bash
-DIR=<absolute path of cloned tumult repository>
+DIR=<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>
 export PYTHONPATH=$PYTHONPATH:$DIR/safetab_p
 export PYTHONPATH=$PYTHONPATH:$DIR/safetab_utils
-export PYTHONPATH=$PYTHONPATH:$DIR/core
-export PYTHONPATH=$PYTHONPATH:$DIR/common
-export PYTHONPATH=$PYTHONPATH:$DIR/analytics
+export PYTHONPATH=$PYTHONPATH:$DIR/tumult/core
+export PYTHONPATH=$PYTHONPATH:$DIR/tumult/common
+export PYTHONPATH=$PYTHONPATH:$DIR/tumult/analytics
 ```
 
 `PYTHONPATH` also needs to be updated to include a Census Edited File (CEF) reader module for SafeTab `safetab_cef_reader.py`. This can be either MITRE’s CEF reader (developed separately), or the built-in mock CEF reader: `safetab_p/tmlt/mock_cef_reader`. Note that the mock CEF reader does not actually read CEF files, so it can only be used if input is being read from CSV files.
 
 ```bash
-export PYTHONPATH=<absolute path to directory containing safetab_cef_reader.py>:$PYTHONPATH
+export PYTHONPATH=<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/mitre:$PYTHONPATH
 ```
 
 If using MITRE's CEF reader, you will also need to include its dependencies, which can be found in its `das_decennial` directory:

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -79,6 +79,7 @@ popd
 The below spark-submit commands demonstrates running SafeTab-P command line program to produce private tabulations followed by output validation on toy dataset and a csv reader.
 
 ```bash
+pushd tmlt/safetab_p
 spark-submit \
         --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
         tmlt/safetab_p/safetab-p.py execute tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp>  \

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -17,9 +17,9 @@ Execute the following to run the tests:
 *Fast Tests:*
 
 ```bash
-DIR=<path of cloned repository>
-python3 -m nose $DIR/common -a '!slow'
-python3 -m pytest $DIR/analytics -m 'not slow'
+DIR=<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>
+python3 -m nose $DIR/tumult/common -a '!slow'
+python3 -m pytest $DIR/tumult/analytics -m 'not slow'
 python3 -m nose $DIR/safetab_p -a '!slow'
 python3 -m nose $DIR/safetab_utils -a '!slow'
 (Total runtime estimate: 20 minutes)
@@ -28,9 +28,9 @@ python3 -m nose $DIR/safetab_utils -a '!slow'
 *Slow Tests:*
 
 ```bash
-DIR=<path of cloned repository>
-python3 -m nose $DIR/common -a 'slow'
-python3 -m pytest $DIR/analytics -m 'slow'
+DIR=<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>
+python3 -m nose $DIR/tumult/common -a 'slow'
+python3 -m pytest $DIR/tumult/analytics -m 'slow'
 python3 -m nose $DIR/safetab_p -a 'slow'
 python3 -m nose $DIR/safetab_utils -a 'slow'
 (Total runtime estimate: 140 minutes)
@@ -38,12 +38,14 @@ python3 -m nose $DIR/safetab_utils -a 'slow'
 
 ## SafeTab-P's tests
 
+*All tests are deisgned to be run from the directory `<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p/tmlt/safetab_p`.*
+
 ### Unit Tests:
 
 SafeTab-P unit tests test the individual components of the algorithm like characteristic iteration flat maps, region preprocessing, and accuracy report components.
 
 ```
-python3 -m nose safetab_p/test/unit
+python3 -m nose test/unit
 (Runtime estimate: 45 seconds)
 ```
 
@@ -54,18 +56,16 @@ python3 -m nose safetab_p/test/unit
    * Tests that SafeTab-P raises appropriate exceptions when invalid arguments are supplied and that SafeTab-P runs the full algorithm for US and/or Puerto Rico depending on input supplied.
 
 ```
-python3 -m nose safetab_p/test/system/test_input_validation.py
+python3 -m nose test/system/test_input_validation.py
 (Runtime estimate: 3 minutes)
 ```
 
  The below spark-submit commands demonstrates running SafeTab-P command line program in input `validate` mode on toy dataset and a csv reader. To validate with the CEF reader, see instructions in the [README](./README.md).
 
-*Run from the directory `safetab_p/tmlt/safetab_p`.*
-
 ```bash
 spark-submit \
-        --properties-file resources/spark_configs/spark_local_properties.conf \
-        ./safetab-p.py validate resources/toy_dataset/input_dir_<puredp or zcdp> \
+        --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
+        tmlt/safetab_p/safetab-p.py validate tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp> \
          resources/toy_dataset
 (Runtime estimate: 35 seconds)
 ```
@@ -76,13 +76,11 @@ spark-submit \
 
 The below spark-submit commands demonstrates running SafeTab-P command line program to produce private tabulations followed by output validation on toy dataset and a csv reader.
 
-*Run from the directory `safetab_p/tmlt/safetab_p`.*
-
 ```bash
 spark-submit \
-        --properties-file resources/spark_configs/spark_local_properties.conf \
-        ./safetab-p.py execute resources/toy_dataset/input_dir_<puredp or zcdp>  \
-        resources/toy_dataset  \
+        --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
+        tmlt/safetab_p/safetab-p.py execute tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp>  \
+        tmlt/safetab_p/resources/toy_dataset  \
         example_output/safetab_p --validate-private-output
 (Runtime estimate: 4 minutes)
 ```
@@ -96,7 +94,7 @@ spark-submit \
    * A test ensures that the SafeTab-P algorithm determines the correct statistic level and computes the correct aggregate counts when the noise addition is turned off.
 
 ```
-python3 -m nose safetab_p/test/system/test_correctness.py
+python3 -m nose test/system/test_correctness.py
 (Runtime estimate: 2 hours and 10 minutes)
 ```
 
@@ -106,11 +104,11 @@ python3 -m nose safetab_p/test/system/test_correctness.py
 
    * Calculates the observed error between the noisy and ground-truth results.
 
-Run [`safetab_p/examples/multi_run_error_report_p.py`](examples/multi_run_error_report_p.py) to compare the results from SafeTab-P algorithm execution against the ground truth (non-private) answers across multiple trials and privacy budgets. This example script runs the SafeTab-P program on non-sensitive data present in input path (`safetab_p/tmlt/safetab_p/resources/toy_dataset`) for 5 trials, epsilons specified in [`safetab_p/tmlt/safetab_p/resources/toy_dataset/input_dir_puredp/config.json`](tmlt/safetab_p/resources/toy_dataset/input_dir_puredp/config.json) for each combination of geography level and iteration level. It produces ground truth tabulations `t1/*.csv` and `t2/*.csv` in directory (`safetab_p/example_output/multi_run_error_report_p/ground_truth`). Private tabulations `t1/*.csv` and `t2/*.csv` for each run can be found in the directory (`safetab_p/example_output/multi_run_error_report_p/single_runs`). The aggregated error report `multi_run_error_report.csv` is saved to output directory (`safetab_p/example_output/multi_run_error_report_p/full_error_report`).
+Run [`examples/multi_run_error_report_p.py`](examples/multi_run_error_report_p.py) to compare the results from SafeTab-P algorithm execution against the ground truth (non-private) answers across multiple trials and privacy budgets. This example script runs the SafeTab-P program on non-sensitive data present in input path (`tmlt/safetab_p/resources/toy_dataset`) for 5 trials, epsilons specified in [`tmlt/safetab_p/resources/toy_dataset/input_dir_puredp/config.json`](tmlt/safetab_p/resources/toy_dataset/input_dir_puredp/config.json) for each combination of geography level and iteration level. It produces ground truth tabulations `t1/*.csv` and `t2/*.csv` in directory (`example_output/multi_run_error_report_p/ground_truth`). Private tabulations `t1/*.csv` and `t2/*.csv` for each run can be found in the directory (`example_output/multi_run_error_report_p/single_runs`). The aggregated error report `multi_run_error_report.csv` is saved to output directory (`example_output/multi_run_error_report_p/full_error_report`).
 
 
 ```bash
-safetab_p/examples/multi_run_error_report_p.py
+python3 examples/multi_run_error_report_p.py
 (Runtime estimate: 15 minutes)
 ```
 
@@ -119,6 +117,6 @@ Note: Multi-run error report uses the ground truth counts. It violates different
    * Tests that running the full accuracy report creates the appropriate output directories for SafeTab-P algorithm.
 
 ```
-python3 -m nose safetab_p/test/system/test_accuracy_report.py
+python3 -m nose test/system/test_accuracy_report.py
 (Runtime estimate: 25 minutes)
 ```

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -38,7 +38,7 @@ python3 -m nose $DIR/safetab_utils -a 'slow'
 
 ## SafeTab-P's tests
 
-*All tests are deisgned to be run from the directory `<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p/tmlt/safetab_p`.*
+*All tests are designed to be run from the directory `<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p/tmlt/safetab_p`.*
 
 ### Unit Tests:
 

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -81,10 +81,11 @@ The below spark-submit commands demonstrates running SafeTab-P command line prog
 ```bash
 pushd tmlt/safetab_p
 spark-submit \
-        --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
-        tmlt/safetab_p/safetab-p.py execute tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp>  \
-        tmlt/safetab_p/resources/toy_dataset  \
+        --properties-file resources/spark_configs/spark_local_properties.conf \
+        safetab-p.py execute resources/toy_dataset/input_dir_<puredp or zcdp>  \
+        resources/toy_dataset  \
         example_output/safetab_p --validate-private-output
+popd
 (Runtime estimate: 4 minutes)
 ```
 

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -65,9 +65,10 @@ python3 -m nose test/system/test_input_validation.py
 ```bash
 pushd tmlt/safetab_p
 spark-submit \
-        --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
-        tmlt/safetab_p/safetab-p.py validate tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp> \
-        tmlt/safetab_p/resources/toy_dataset
+        --properties-file resources/spark_configs/spark_local_properties.conf \
+        safetab-p.py validate resources/toy_dataset/input_dir_<puredp or zcdp> \
+        resources/toy_dataset
+popd
 (Runtime estimate: 35 seconds)
 ```
 

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -63,6 +63,7 @@ python3 -m nose test/system/test_input_validation.py
  The below spark-submit commands demonstrates running SafeTab-P command line program in input `validate` mode on toy dataset and a csv reader. To validate with the CEF reader, see instructions in the [README](./README.md).
 
 ```bash
+pushd tmlt/safetab_p
 spark-submit \
         --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
         tmlt/safetab_p/safetab-p.py validate tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp> \

--- a/safetab_p/TESTPLAN.md
+++ b/safetab_p/TESTPLAN.md
@@ -38,7 +38,7 @@ python3 -m nose $DIR/safetab_utils -a 'slow'
 
 ## SafeTab-P's tests
 
-*All tests are designed to be run from the directory `<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p/tmlt/safetab_p`.*
+*All tests are designed to be run from the directory `<absolute path of cloned DAS_2020_DDHCA_Production_Code repository>/safetab_p`.*
 
 ### Unit Tests:
 
@@ -66,7 +66,7 @@ python3 -m nose test/system/test_input_validation.py
 spark-submit \
         --properties-file tmlt/safetab_p/resources/spark_configs/spark_local_properties.conf \
         tmlt/safetab_p/safetab-p.py validate tmlt/safetab_p/resources/toy_dataset/input_dir_<puredp or zcdp> \
-         resources/toy_dataset
+        tmlt/safetab_p/resources/toy_dataset
 (Runtime estimate: 35 seconds)
 ```
 

--- a/safetab_p/examples/repo_zip.sh
+++ b/safetab_p/examples/repo_zip.sh
@@ -3,7 +3,7 @@
 # This script has dependency on associative arrays and requires bash version 4+.
 
 usage() {
-    echo "Usage: $0 -t <path to safetab-p repository> [-r <path to CEF reader] " 1>&2; exit 1;
+    echo "Usage: $0 -t <path to DAS_2020_DDHCA_Production_Code repository> [-r <path to CEF reader] " 1>&2; exit 1;
 }
 
 while getopts t:r: flag
@@ -25,14 +25,17 @@ do
 done
 
 repo_zip=$(readlink -f $staging_repo)/repo.zip
-for m in common core analytics safetab_p safetab_utils; do
+for m in safetab_p safetab_utils; do
     pushd $staging_repo/$m
     zip -r $repo_zip tmlt
     popd
 done
 
-echo "Removing mock cef reader"
-zip -d $repo_zip "tmlt/mock_cef_reader/*"
+for m in common analytics; do
+    pushd $staging_repo/tumult/$m
+    zip -r $repo_zip tmlt
+    popd
+done
 
 pushd $staging_repo
 touch "__init__.py"

--- a/tumult/README.md
+++ b/tumult/README.md
@@ -13,9 +13,9 @@ Copyright 2023 Tumult Labs
    See the License for the specific language governing permissions and
    limitations under the License.
 
-## Tumult Contents
+## Supporting Libraries Developed by Tumult Labs
 
-This directory contains SafeTab-P's supporting Tumult-developed libraries. There are three folders, each of which contains a Python library used by SafeTab-P. For instructions on running SafeTab-P, see its [README](../safetab_p/README.md).
+This directory contains SafeTab-P's supporting libraries developed by Tumult Labs. There are three folders, each of which contains a Python library used by SafeTab-P. For instructions on running SafeTab-P, see its [README](../safetab_p/README.md).
 
 - **Core 0.6.0**: A Python library for performing differentially private computations. The design of Tumult Core is based on the design proposed in the [OpenDP White Paper](https://projects.iq.harvard.edu/files/opendp/files/opendp_programming_framework_11may2020_1_01.pdf), and can automatically verify the privacy properties of algorithms constructed from Tumult Core components. Tumult Core is scalable, includes a wide variety of components to handle various query types, and supports multiple privacy definitions. This library is available as an independent open-source release. For more, see its software documentation at https://docs.tmlt.dev/core/v0.6/.
 - **Analytics 0.5.3**: A Python library for privately answering statistical queries on tabular data, implemented using Tumult Core. It is built on PySpark, allowing it to scale to large datasets. Its privacy guarantees are based on differential privacy, a technique that perturbs statistics to provably protect the data of individuals in the original dataset. This library is available as an independent open-source release. For more, see its software documentation at https://docs.tmlt.dev/analytics/v0.5/.

--- a/tumult/README.md
+++ b/tumult/README.md
@@ -13,32 +13,12 @@ Copyright 2023 Tumult Labs
    See the License for the specific language governing permissions and
    limitations under the License.
 
-## SafeTab-P 5.0.0
+## Tumult Contents
 
-This repository contains SafeTab-P and its supporting Tumult-developed libraries. For instructions on running SafeTab-P, see its [README](../safetab_p/README.md).
-
-### Access to the Deliverable
-
-The source code and documentation for this deliverable can be accessed by executing the following command at the command line (or entering the URL into the clone window of a client, e.g., Github Desktop):
-
-```
-git clone https://gitlab.com/tumult-labs/safetab-p-release.git
-```
-
-
-
-### Contents
-
-In the repository there are five folders, each of which contains a component of the release:
+This directory contains SafeTab-P's supporting Tumult-developed libraries. There are three folders, each of which contains a Python library used by SafeTab-P. For instructions on running SafeTab-P, see its [README](../safetab_p/README.md).
 
 - **Core 0.6.0**: A Python library for performing differentially private computations. The design of Tumult Core is based on the design proposed in the [OpenDP White Paper](https://projects.iq.harvard.edu/files/opendp/files/opendp_programming_framework_11may2020_1_01.pdf), and can automatically verify the privacy properties of algorithms constructed from Tumult Core components. Tumult Core is scalable, includes a wide variety of components to handle various query types, and supports multiple privacy definitions. This library is available as an independent open-source release. For more, see its software documentation at https://docs.tmlt.dev/core/v0.6/.
 - **Analytics 0.5.3**: A Python library for privately answering statistical queries on tabular data, implemented using Tumult Core. It is built on PySpark, allowing it to scale to large datasets. Its privacy guarantees are based on differential privacy, a technique that perturbs statistics to provably protect the data of individuals in the original dataset. This library is available as an independent open-source release. For more, see its software documentation at https://docs.tmlt.dev/analytics/v0.5/.
 - **Common 0.8.1**: A Python library with utilities for reading and validating data. Code in Common is designed not to be specific to Census applications.
-- **SafeTab-Utils 0.5.3**: A Python library that implements pieces of Census business logic that are shared between multiple Census products. Includes code for processing characteristic iterations and geographies, performing additional, product-specific validation, and reading in Census data.
-- **SafeTab-P 5.0.0**: The main program of this release. It produces the Detailed DHC-A.
-
-SafeTab-P also requires a CEF reader module for reading data from Census' file formats. The CEF reader is implemented separately, and is therefore not included in this release. We do include a built-in alternative reader that gets data from CSV files. When using the CSV reader, the CEF reader can be replaced by the included [mock CEF reader](../safetab_p/tmlt/mock_cef_reader).
 
 For details, consult each library's `README` within its respective subfolder. To see which new features have been added since the previous versions, consult their respective `CHANGELOG`s.
-
-


### PR DESCRIPTION
This pull request does the following:
(1) Updates the Census' documentation, focusing on making references to Tumult Labs conform to Tumult Labs' branding conventions
(2) Modifies the SafeTab-P and Tumult Labs developed library documentation to account for the new repository structure in the public SafeTab-P release. Mainly this involves updating paths. 
(3) Modifies the repo_zip.sh script to account for the new repository structure. This is the only non-documentation change.

Tumult Labs is requesting this change to make the documentation more readable and applicable for non-Census parties. It should not impact the Census' use of SafeTab-P. 
